### PR TITLE
Enable private subnets to be created in Outposts

### DIFF
--- a/private.tf
+++ b/private.tf
@@ -17,6 +17,7 @@ resource "aws_subnet" "private" {
   vpc_id            = var.vpc_id
   availability_zone = each.key
   cidr_block        = cidrsubnet(var.cidr_block, ceil(log(var.max_subnets, 2)), each.value)
+  outpost_arn       = var.outpost_arn
 
   tags = merge(
     module.private_label.tags,

--- a/variables.tf
+++ b/variables.tf
@@ -132,3 +132,9 @@ variable "ipv6_cidr_block" {
   description = "Base IPv6 CIDR block which is divided into /64 subnet CIDR blocks"
   default     = null
 }
+
+variable "outpost_arn" {
+  type        = string
+  description = "Outpost ARN to create the subnet"
+  default     = null
+}


### PR DESCRIPTION
## what
* We want to be able to use Outposts for private subnets.

## why
* We use AWS Outposts as an extension of our cloud.

